### PR TITLE
Link rel preload support

### DIFF
--- a/dist/expose.js
+++ b/dist/expose.js
@@ -1,0 +1,1 @@
+module.exports = {__dirname};

--- a/dist/server.mjs
+++ b/dist/server.mjs
@@ -1,10 +1,11 @@
-const fs = require('fs');
-const path = require('path');
-const polka = require('polka');
+import fs from 'fs';
+import path from 'path';
+import polka from 'polka';
+import expose from './expose.js';
 
 polka()
   .get('/js/:file', (req, res) => {
-    const file = path.resolve(__dirname, req.params.file);
+    const file = path.resolve(expose.__dirname, req.params.file);
     let stream = fs.createReadStream(file);
 
     stream.on('error', error => {
@@ -29,6 +30,7 @@ polka()
     });
   })
   .get('/', (req, res) => {
+    res.setHeader('Link', '</js/output-modules.js>; rel=preload; crossorigin=anonymous; as=script');
     res.end(`
     <!doctype html>
     <html>
@@ -37,7 +39,7 @@ polka()
       <title>Modules / No Modules Example</title>
       <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
       <script>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
-      <script type="module" src="/js/output-modules.js"></script>
+      <script type="module" crossorigin="anonymous" src="/js/output-modules.js"></script>
       <script nomodule src="/js/output-nomodules.js"></script>
     </head>
     <body>

--- a/expose.js
+++ b/expose.js
@@ -1,0 +1,1 @@
+module.exports = {__dirname};

--- a/package.json
+++ b/package.json
@@ -1,24 +1,30 @@
 {
   "name": "preset-env-modules",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Demonstrate Babel Preset Env with ESModules Support.",
   "main": "index.js",
   "author": "Kristofer Baxter",
   "license": "Apache-2.0",
+  "engines": {
+    "yarn": ">=1.7.0",
+    "node": ">=8.10.0"
+  },
   "scripts": {
-    "start": "yarn clean; yarn test; cp server.js dist/server.js; node dist/server.js",
-    "clean": "rm -rf dist/*",
-    "test": "yarn build:modules; yarn build:nomodules",
+    "prestart": "rimraf dist/*; cp server.mjs expose.js dist/",
+    "start": "yarn build; node -r esm dist/server.mjs",
+    "build": "yarn build:modules & yarn build:nomodules & wait",
     "build:modules": "BABEL_ENV=esmodules yarn babel input.js -o dist/output-modules.js",
     "build:nomodules": "BABEL_ENV=nomodules yarn babel input.js -o dist/output-nomodules.js"
   },
   "dependencies": {
-    "polka": "^0.2.0"
+    "polka": "0.4.0"
   },
   "devDependencies": {
-    "@babel/cli": "v7.0.0-beta.39",
-    "@babel/core": "v7.0.0-beta.39",
-    "@babel/preset-env": "v7.0.0-beta.39",
-    "babel-plugin-inline-replace-variables": "^1.3.1"
+    "@babel/cli": "v7.0.0-rc.1",
+    "@babel/core": "v7.0.0-rc.1",
+    "@babel/preset-env": "v7.0.0-rc.1",
+    "babel-plugin-inline-replace-variables": "1.3.1",
+    "esm": "3.0.76",
+    "rimraf": "2.6.2"
   }
 }

--- a/server.mjs
+++ b/server.mjs
@@ -1,10 +1,11 @@
-const fs = require('fs');
-const path = require('path');
-const polka = require('polka');
+import fs from 'fs';
+import path from 'path';
+import polka from 'polka';
+import expose from './expose.js';
 
 polka()
   .get('/js/:file', (req, res) => {
-    const file = path.resolve(__dirname, req.params.file);
+    const file = path.resolve(expose.__dirname, req.params.file);
     let stream = fs.createReadStream(file);
 
     stream.on('error', error => {
@@ -29,6 +30,7 @@ polka()
     });
   })
   .get('/', (req, res) => {
+    res.setHeader('Link', '</js/output-modules.js>; rel=preload; crossorigin=anonymous; as=script');
     res.end(`
     <!doctype html>
     <html>
@@ -36,7 +38,8 @@ polka()
       <meta charset="utf-8">
       <title>Modules / No Modules Example</title>
       <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
-      <script type="module" src="/js/output-modules.js"></script>
+      <script>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()},!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
+      <script type="module" crossorigin="anonymous" src="/js/output-modules.js"></script>
       <script nomodule src="/js/output-nomodules.js"></script>
     </head>
     <body>


### PR DESCRIPTION
Link Rel Preload is a bit tricky with `module`/`nomodule` patterns.

Here we show how one can preload a module (and fallback to the nomodule script) using crossorigin attributes on the `script type=module` tag and the `Link` header. 